### PR TITLE
Minor fix for Setup-Computer-PRC article

### DIFF
--- a/content/article/setup-your-computer-for-cpan-prc.md
+++ b/content/article/setup-your-computer-for-cpan-prc.md
@@ -84,7 +84,7 @@ This command changes the owner of the cpanm folder, which usually fixes the issu
 
 You need to install homebrew:
 
-    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 #### 1: Install Perlbrew
 
@@ -100,7 +100,7 @@ Now that we have Perlbrew in place, we can go ahead and install a Perl on our ow
 
     $ perlbrew install -j 4 perl-stable
 
-There are two ways to use a Perl version with Perlbrew: `use` and `switch`. `use` is temporary, it goes away once you close the terminal. That's why I recommend `switch`, which will make it permanent.
+There are two ways to use a Perl version with Perlbrew: `use` and `switch`. `use` is temporary, it goes away once you close the terminal. That's why I recommend `switch`, which will make it permanent. Change the version to the one you just installed. You can run `perlbrew list` to see installed versions.
 
     $ perlbrew switch perl-5.26.1
 


### PR DESCRIPTION
1) There was a backtick left at the end of a command.
   When you copy paste, it wouldn't be run successfully.

2) I do recommended installing "latest stable" and then switching
   to "5.26.1", which is no longer latest stable version.
   So I thought adding a note might be helpful for future readers.