### PR TITLE
Update baseurl to be www.perl.com

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://perl.com/"
+baseURL = "https://www.perl.com/"
 languageCode = "en-us"
 title = "Perl.com - programming news, code and culture"
 paginate = 20
@@ -16,5 +16,5 @@ category = "categories"
 legacy=":slug"
 
 [params]
-github="https://github.com/tpf/perldotcom"
+github="https://github.com/perladvent/perldotcom"
 description = "Since 1997 Perl.com has published articles about the Perl programming language, its culture and community."


### PR DESCRIPTION
Fastly redirects there anyway, so save some redirects
