### PR TITLE
Fix deprecation warning by switching from Mojo::File::spurt to Mojo::File::spew

### DIFF
--- a/bin/collate_metadata
+++ b/bin/collate_metadata
@@ -53,12 +53,12 @@ $dir->make_path;
 my $j = JSON::XS->new->utf8->pretty(1);
 
 my @all_articles = sort { $b->{epoch} <=> $a->{epoch} } values %all_articles;
-$dir->child( 'all_articles.json' )->spurt(
-	$j->encode( \@all_articles )
+$dir->child( 'all_articles.json' )->spew(
+	join '', $j->encode( \@all_articles )
 	);
 
-$dir->child( 'previous_ten_articles.json' )->spurt(
-	$j->encode( [ @all_articles[0..9] ] )
+$dir->child( 'previous_ten_articles.json' )->spew(
+	join '', $j->encode( [ @all_articles[0..9] ] )
 	);
 
 my %by = (
@@ -70,17 +70,18 @@ my %by = (
 foreach my $subdir ( qw(tags categories authors) ) {
 	$dir->child( $by{$subdir} )->make_path;
 	my @values = keys $grand_collation{$subdir}->%*;
-	$dir->child( "$subdir.json" )->spurt(
-		$j->encode( [
-			map $_->[0],
-			sort { $a->[1] cmp $b->[1] }
-			map [$_,lc],
-			@values ] )
+	$dir->child( "$subdir.json" )->spew(
+		join '',
+			$j->encode( [
+				map $_->[0],
+				sort { $a->[1] cmp $b->[1] }
+				map [$_,lc],
+				@values ] )
 		);
 
 	foreach my $value ( keys $grand_collation{$subdir}->%* ) {
-		$dir->child( $by{$subdir}, "$value.json" )->spurt(
-			$j->encode( $grand_collation{$subdir}{$value} )
+		$dir->child( $by{$subdir}, "$value.json" )->spew(
+			join '', $j->encode( $grand_collation{$subdir}{$value} )
 			);
 		}
 	}

--- a/cpanfile
+++ b/cpanfile
@@ -12,7 +12,7 @@ requires 'Imager';
 requires 'JSON::MaybeXS.pm';
 requires 'JSON::XS';
 requires 'List::Util';
-requires 'Mojolicious';
+requires 'Mojolicious', '9.34';
 requires 'Path::Tiny';
 requires 'Term::ANSIColor';
 requires 'Text::CSV';


### PR DESCRIPTION
Fixes #369 

Annoyingly, Mojolicious added `spew()` and deprecated `spurt()` in the same release (9.34 from September 2023), so anyone running an older version of Mojolicious will a) not see this deprecation warning and b) won't be able to run this fixed version.

So maybe you want to hold off merging this until you know more developers are running a sufficiently up-to-date version of Mojolicious.