### PR TITLE
Convert :utf8 to :encoding(UTF8) in unicode cookbook

### DIFF
--- a/content/legacy/_pub_2012_04_perlunicook-decode-standard-filehandles-as-utf-8.md
+++ b/content/legacy/_pub_2012_04_perlunicook-decode-standard-filehandles-as-utf-8.md
@@ -28,7 +28,7 @@ As documented in [perlrun]({{<perldoc "perlrun" >}}), the `PERL_UNICODE` environ
 
 Within your program, the [open]({{<perldoc "open" >}}) pragma allows you to set the default encoding of these filehandles all at once:
 
-         use open qw(:std :utf8);
+         use open qw(:std :encoding(UTF-8));
 
 Because Perl uses IO layers to implement encoding and decoding, you may also use the [binmode]({{<perlfunc "binmode" >}}) operator on filehandles directly:
 

--- a/content/legacy/_pub_2012_04_perlunicook-standard-preamble.md
+++ b/content/legacy/_pub_2012_04_perlunicook-standard-preamble.md
@@ -29,7 +29,7 @@ Unless otherwise noted, all examples in this cookbook require this standard prea
      use strict;    # quote strings, declare variables
      use warnings;  # on by default
      use warnings  qw(FATAL utf8);    # fatalize encoding glitches
-     use open      qw(:std :utf8);    # undeclared streams in UTF-8
+     use open      qw(:std :encoding(UTF-8)); # undeclared streams in UTF-8
      use charnames qw(:full :short);  # unneeded in v5.16
 
 This *does* make even Unix programmers `binmode` your binary streams, or open them with `:raw`, but that's the only way to get at them portably anyway.

--- a/content/legacy/_pub_2012_05_perlunicook-make-all-io-default-to-utf-8.md
+++ b/content/legacy/_pub_2012_05_perlunicook-make-all-io-default-to-utf-8.md
@@ -28,7 +28,7 @@ If you've configured everything such that all incoming and outgoing data uses th
 
 Within your program, you can achieve the same effects with the [open](http://perldoc.perl.org/open.html) pragma to set default encodings on filehandles and the [Encode](http://perldoc.perl.org/Encode.html) module to decode the elements of `@ARGV`:
 
-         use open qw(:std :utf8);
+         use open qw(:std :encoding(UTF-8));
          use Encode qw(decode_utf8);
          @ARGV = map { decode_utf8($_, 1) } @ARGV;
 

--- a/content/legacy/_pub_2012_05_perlunicook-make-file-io-default-to-utf-8.md
+++ b/content/legacy/_pub_2012_05_perlunicook-make-file-io-default-to-utf-8.md
@@ -30,7 +30,7 @@ Alternately, you can set the default encoding on all filehandles through the ent
 
 The [open](http://perldoc.perl.org/open.html) pragma configures the default encoding of all filehandle operations in its lexical scope:
 
-         use open qw(:utf8);
+         use open qw(:encoding(UTF-8));
 
 Note that the `open` pragma is currently incompatible with the [`autodie`](http://perldoc.perl.org/autodie.html) pragma.
 

--- a/content/legacy/_pub_2012_06_perlunicook-demo-of-unicode-collation-and-printing.md
+++ b/content/legacy/_pub_2012_06_perlunicook-demo-of-unicode-collation-and-printing.md
@@ -56,7 +56,7 @@ Here's that program; tested on v5.14.
      use strict;
      use warnings;
      use warnings  qw(FATAL utf8);    # fatalize encoding faults
-     use open      qw(:std :utf8);    # undeclared streams in UTF-8
+     use open      qw(:std :encoding(utf-8)); # undeclared streams in UTF-8
      use charnames qw(:full :short);  # unneeded in v5.16
 
      # std modules


### PR DESCRIPTION
In practice, only 'use open' needed to be changed. Uses in 'binmode' had already been fixed.