### PR TITLE
remove index and rindex from negative subscript #412

### DIFF
--- a/content/legacy/_doc_FMTEYEWTK_style_slide16.md
+++ b/content/legacy/_doc_FMTEYEWTK_style_slide16.md
@@ -15,7 +15,7 @@
 
 
 -   To get the last element in a list or array, use `$array[-1]` instead of `$array[$#array]`. The former works on both lists and arrays, but the latter does not.
--   Remember that `substr`, `index`, `rindex`, and `splice` also accept negative subscripts to count back from the end.
+-   Remember that `substr` and `splice` also accept negative subscripts to count back from the end.
 
             split(@array, -2);   # pop twice
 


### PR DESCRIPTION
As noted in #412 , `index` and `rindex` turn negative subscripts into the first position in the string and subscripts larger than the length of the string into the end. Just remove those from the sentence since no examples are shown.