### PR TITLE
Update inline code to reflect changes in gist

### DIFF
--- a/content/article/enhancing-midi-hardware-with-perl.md
+++ b/content/article/enhancing-midi-hardware-with-perl.md
@@ -160,8 +160,6 @@ Methods for filtering incoming MIDI events are as follows:
         for my $filter ( $event_filters->@* ) {
             return if $filter->( $self, $event );
         }
-
-        $self->send( $event );
     }
 
     async method _process_midi_events {
@@ -547,8 +545,6 @@ class MidiFilter {
         for my $filter ( $event_filters->@* ) {
             return if $filter->( $self, $event );
         }
-
-        $self->send( $event );
     }
 
     async method _process_midi_events {


### PR DESCRIPTION
Hi @oalders!

I spotted a bug in the implementation of MIDI filters when working with @ology on some stuff. This change just updates the inline code to reflect the changes in the [linked gist](https://gist.github.com/jbarrett/ff611962349a1ce03f49fd9fdfc92119).

Thanks!