### PR TITLE
Handle plain dates in article metadata

### DIFF
--- a/lib/Local/Metadata.pm
+++ b/lib/Local/Metadata.pm
@@ -284,7 +284,14 @@ Returns an integer version of the publication date.
 # 2016-05-04T20:37:57
 sub _date_to_epoch ( $self ) {
 	my $date = $self->{date};
- 	$date .= 'Z' unless $date =~ /[+-]\d\d:?\d\d\z/;
+        # handle dates without any time info
+        if ($date =~ /\A\d{4}-\d{2}-\d{2}\z/) {
+            $date .= 'T12Z';
+        }
+        # handle dates without timezone info
+        elsif ($date !~ /[+-]\d\d:?\d\d\z/) {
+            $date .= 'Z';
+        }
 	my $epoch = eval {
 		Time::Moment->from_string( $date )->epoch
 		};

--- a/t/metadata.t
+++ b/t/metadata.t
@@ -42,4 +42,17 @@ subtest extract => sub {
 	isa_ok $metadata->augmented, ref {}, "augmented section is there";
 	};
 
+subtest dates => sub {
+	my $metadata = $class->new_from_file( $test_file );
+
+	$metadata->{date} = '2016-05-04T20:37:57';
+	is $metadata->_date_to_epoch, 1462394277, "epoch correct for date without timezone";
+
+	$metadata->{date} = '2012-12-31T06:00:01-08:00';
+	is $metadata->_date_to_epoch, 1356962401, "epoch correct for date with timezone";
+
+	$metadata->{date} = '2025-01-29';
+	is $metadata->_date_to_epoch, 1738152000, "epoch correct for date without time info";
+};
+
 done_testing();


### PR DESCRIPTION
While building the site recently (via `make start`), I noticed these error messages appear in the log output:

```
Couldn't parse <2025-01-29> (2025-01-29Z) as a date for <content/article/enhancing-midi-hardware-with-perl.md> at bin/collate_metadata line 26.
Couldn't parse <2025-02-20> (2025-02-20Z) as a date for <content/article/what-s-new-on-cpan---january-2025.md> at bin/collate_metadata line 26.
```

This is because a plain date without time information was not able to be parsed into an epoch within `Local::Metadata`.  The root cause was that the plain date string `2025-02-20` had `Z` appended to it to make its timezone to be UTC, however since there was no time information to begin with, `Time::Moment->from_string()` couldn't parse the string as a date, thus causing the error message.

The solution I came up with was to append `T12Z` to the date string, so that it now looks like e.g. `2025-02-20T12Z` (i.e. midday UTC) and thus making it parseable by `Time::Moment->from_string()`.

I've added tests to check the date handling behaviour in `Local::Metadata->_date_to_epoch()`.  I'm aware that this tests a "private" method, however the alternative would have been to create two new test input files checking the relevant behaviour and I feel that doing so would have made testing more difficult.  The test code I propose is more direct and one sees the details of checking the various date strings which need to be handled in `_date_to_epoch()` as opposed to the date strings being hidden in an extra test file.

With this change, the two recent articles which only use plain dates have their metadata created correctly and the parser error messages no longer appear in the `make start` log output.