### PR TITLE
Enable emoji in markdown

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -5,6 +5,7 @@ disablePathToLower = true
 pygmentsCodeFences = true
 pygmentsStyle = "monokai"
 rssLimit = 25
+enableEmoji = true
 
 [markup.goldmark.renderer]
 # Permit raw HTML in articles, they are reviewed.


### PR DESCRIPTION
This config change allows authors to use emoji within articles.  For example, one can write `:tada:` to get the :tada: emoji, or `:smiley:` to produce the standard :smiley: emoji.  I believe (but couldn't find in the Hugo docs) that the supported emoji are [those present in GitHub markdown](https://gist.github.com/rxaviers/7360908).