### PR TITLE
Specify Hugo config file explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ contributors:
 
 .PHONY: start
 start: json contributors ## start the local server
-	hugo server --buildDrafts --buildFuture --disableFastRender -d built
+	hugo server --buildDrafts --buildFuture --disableFastRender -d built --config hugo.toml
 
 .PHONY: legacy-start
 legacy-start: json contributors ## start the local server
-	docker run --rm -it -v $(PWD):/src -p 1313:1313 klakegg/hugo:0.59.1-ubuntu server --buildDrafts --buildFuture --disableFastRender -d built
+	docker run --rm -it -v $(PWD):/src -p 1313:1313 klakegg/hugo:0.59.1-ubuntu server --buildDrafts --buildFuture --disableFastRender -d built --config hugo.toml
 
 .PHONY: deploy
 deploy: on_master json contributors ## deploy the website to the static repo


### PR DESCRIPTION
The [recent change to use the up-to-date `hugo.toml` name for the Hugo configuration
file](https://github.com/perladvent/perldotcom/commit/afefaf92482f7e275ce4151c1aecd69f6f809c1b) unfortunately broke builds for those stuck using older Hugo versions. This impacted not only those using the `start` `make` target but also the `legacy-start` target.

The error message when building and starting the site was:

```
Error: Unable to locate config file or config directory. Perhaps you
need to create a new site.
       Run `hugo help new` for details.
```

To avoid such problems for people using Hugo versions v0.109.0 and older, where the configuration still allows the site to build but can't find the new default configuration file, it makes sense to specify the location of the configuration file on the command line explicitly.  This change also allows the `legacy-start` `make` target to build the site successfully again.