### PR TITLE
Remove unused variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 SITE=https://www.perl.com
 
-HUGO=hugo
-
 JSON_DIRNAME=json
 JSON_LOCAL_DIR=static/$(JSON_DIRNAME)
 


### PR DESCRIPTION
While digging through the `Makefile` code recently, I noticed that the `HUGO` variable wasn't being used anywhere.  Thus, I suspect it can be removed, as implemented in this change.