### PR TITLE
Fix Map::Tube HOWTO descriptions

### DIFF
--- a/content/article/building-map-tube-maps-a-howto-extending-the-network.md
+++ b/content/article/building-map-tube-maps-a-howto-extending-the-network.md
@@ -7,7 +7,7 @@
     "draft"       : false,
     "image"       : "/images/building-map-tube-maps-a-howto/tram-network-langenhagen-hannover-sarstedt-cover.png",
     "thumbnail"   : "/images/building-map-tube-maps-a-howto/Swiss-Cottage-Underground-Station-Jubilee-Line_Hugh-Llewelyn_flickr-To-Trains.jpg",
-    "description" : "Extending the network of a Map::Tube::<*> map",
+    "description" : "Extending the network of a Map::Tube::<*> map.",
     "categories"  : "tutorials",
     "canonicalURL": "https://peateasea.de/building-map-tube-whatever-maps-a-howto-extending-the-network/"
   }

--- a/content/article/building-map-tube-maps-a-howto-first-steps.md
+++ b/content/article/building-map-tube-maps-a-howto-first-steps.md
@@ -7,7 +7,7 @@
     "draft"       : false,
     "image"       : "/images/building-map-tube-maps-a-howto/hannover-tram-langenhagen-cover.png",
     "thumbnail"   : "/images/building-map-tube-maps-a-howto/Swiss-Cottage-Underground-Station-Jubilee-Line_Hugh-Llewelyn_flickr-To-Trains.jpg",
-    "description" : "First steps at how to build your own Map::Tube::<*> map",
+    "description" : "First steps at how to build your own Map::Tube::<*> map.",
     "categories"  : "tutorials",
     "canonicalURL": "https://peateasea.de/building-map-tube-whatever-maps-a-howto-first-steps/"
   }

--- a/content/article/building-map-tube-maps-a-howto-routing-relative-reality.md
+++ b/content/article/building-map-tube-maps-a-howto-routing-relative-reality.md
@@ -7,7 +7,7 @@
     "draft"       : false,
     "image"       : "/images/building-map-tube-maps-a-howto/tram-network-hannover-linie1-linie4-linie7-cover.png",
     "thumbnail"   : "/images/building-map-tube-maps-a-howto/Swiss-Cottage-Underground-Station-Jubilee-Line_Hugh-Llewelyn_flickr-To-Trains.jpg",
-    "description" : "",
+    "description" : "Finding routes between stations in a Map::Tube::<*> map.",
     "categories"  : "tutorials",
     "canonicalURL": "https://peateasea.de/building-map-tube-whatever-maps-a-howto-routing-relative-reality/"
   }

--- a/content/article/building-map-tube-maps-a-howto-weaving-a-web.md
+++ b/content/article/building-map-tube-maps-a-howto-weaving-a-web.md
@@ -7,7 +7,7 @@
     "draft"       : false,
     "image"       : "/images/building-map-tube-maps-a-howto/tram-network-hannover-linie1-linie7-cover.png",
     "thumbnail"   : "/images/building-map-tube-maps-a-howto/Swiss-Cottage-Underground-Station-Jubilee-Line_Hugh-Llewelyn_flickr-To-Trains.jpg",
-    "description" : "",
+    "description" : "Weaving more tram lines into our Map::Tube::<*> map.",
     "categories"  : "tutorials",
     "canonicalURL": "https://peateasea.de/building-map-tube-whatever-maps-a-howto-weaving-a-web/"
   }


### PR DESCRIPTION
While fixing up PR #452, I noticed some issues with descriptions in the previous `Map::Tube` HOWTO articles.  These commits fix the problems.