### PR TITLE
Force word-wrap on smaller screens

### DIFF
--- a/static/css/perldotcom.css
+++ b/static/css/perldotcom.css
@@ -293,6 +293,9 @@ code.language-prettyprint .dec { color: #98fb98 } /* decimal         - lightgree
   .follow,#search {
     display: none;
   }
+  #content {
+    overflow: hidden;
+  }
 }
 @media (max-width: 767px) {
   #search {

--- a/static/css/perldotcom.css
+++ b/static/css/perldotcom.css
@@ -52,6 +52,8 @@ body {
   margin: 0;
   font-family:OpenSansReg;
   color: #292B26;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 h1,h2,h3,h4,h5,h6 {
   color: #292B26;


### PR DESCRIPTION
Fix for #411, force word-wrap on smaller screens, notably visible on long Perl namespaces. 

**Before**
![image](https://github.com/user-attachments/assets/2583e970-d078-42f5-b4a0-411471984e10)

**After**
![image](https://github.com/user-attachments/assets/7542bb6e-829a-4182-bb47-6a86aacb1e3c)


5ad09d2f4a4ab38a8eca0b04534b7e0ba1a8b385 should fix a additional useless horizontal scroll bar on smaller screens that is related to layout. Could be avoided by removing the `.push` container, but requires more investigation about why this container is necessary. Theory: this empty container only serve the purpose of creating a separation between the main container and the footer.
