### PR TITLE
Add canonicalUrl to new article metadata

### DIFF
--- a/bin/new-article
+++ b/bin/new-article
@@ -65,16 +65,16 @@ my $date = $dt->datetime;
 
 print $fh qq(
   {
-    "title"       : "$title",
-    "authors"     : ["$author"],
-    "date"        : "$date",
-    "tags"        : [],
-    "draft"       : false,
-    "image"       : "",
-    "thumbnail"   : "",
-    "description" : "$description",
-    "categories"  : "$category",
-    "canonicalUrl": ""
+    "title"        : "$title",
+    "authors"      : ["$author"],
+    "date"         : "$date",
+    "tags"         : [],
+    "draft"        : false,
+    "image"        : "",
+    "thumbnail"    : "",
+    "description"  : "$description",
+    "categories"   : "$category",
+    "canonicalUrl" : ""
   }
 
 The article body goes here. Don't forget to delete this stuff!

--- a/bin/new-article
+++ b/bin/new-article
@@ -73,7 +73,8 @@ print $fh qq(
     "image"       : "",
     "thumbnail"   : "",
     "description" : "$description",
-    "categories"  : "$category"
+    "categories"  : "$category",
+    "canonicalUrl": ""
   }
 
 The article body goes here. Don't forget to delete this stuff!


### PR DESCRIPTION
I noticed a while ago that Dave Cross had used the `canonicalURL` key in
one of his articles and have hence also used this key in my recent
articles to point to where the article was first published.  To avoid
having to think of adding this key each time myself, I thought it might
be an idea to have this key appear as part of the default new article
metadata, hence the change implemented in this commit.

Note that the key I've added uses a different capitalisation scheme to
that which I mentioned above.  Grepping through the source shows that
`layouts/partials/header.html` uses the value of `.Params.canonicalUrl`
to decide whether or not to include this information in the output HTML
header metadata.  Therefore, I thought it more consistent to use
`canonicalUrl` as opposed to `canonicalURL` for the default metadata
key.

I've also found that using an empty value for `canonicalUrl` provides
the default behaviour that currently exists when this key is not
mentioned in the article metadata.  In other words, setting
`canonicalUrl` to the empty string by default doesn't change the current
behaviour of how HTML is generated on the site.