### PR TITLE
Switch to TOML frontmatter for new articles

### DIFF
--- a/bin/new-article
+++ b/bin/new-article
@@ -12,6 +12,7 @@ use Getopt::Long          qw( GetOptions );
 use I18N::Langinfo        qw( CODESET langinfo );
 use IO::Interactive       qw(is_interactive);
 use Time::Piece           qw( localtime );
+use TOML::Tiny            qw( to_toml );
 
 # check we're in perldotcom
 my $cwd = cwd();
@@ -62,34 +63,34 @@ usage()
 my $filename = lc $title;
 $filename =~ s/\W+/-/g;
 $filename = catfile( qw/content article/, "$filename.md" );
-die "$filename.md already exists!\n" if -e $filename;
-open my $fh, '>:utf8', $filename;
+open my $fh, '>:encoding(UTF-8)', $filename;
 
 my $dt   = localtime;
 my $date = $dt->datetime;
 
-print $fh qq(
-  {
-    "title"        : "$title",
-    "authors"      : ["$author"],
-    "date"         : "$date",
-    "tags"         : [],
-    "draft"        : false,
-    "image"        : "",
-    "thumbnail"    : "",
-    "description"  : "$description",
-    "categories"   : "$category",
-    "canonicalUrl" : ""
-  }
+my %frontmatter = (
+    title        => $title,
+    authors      => [$author],
+    date         => $date,
+    tags         => [],
+    draft        => \0,
+    image        => "",
+    thumbnail    => "",
+    description  => $description // "",
+    categories   => $category,
+    canonicalUrl => ""
+);
 
-The article body goes here. Don't forget to delete this stuff!
+say $fh "+++";
+say $fh to_toml( \%frontmatter );
+say $fh "+++\n";
+print $fh qq(The article body goes here. Don't forget to delete this stuff!
 
 Other resources:
 
 * [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/)
 * [How to write your first article for Perl.com](/article/how-to-write-your-first-article-for-perl-com/)
 * [How to find a programming topic to write about](/article/how-to-find-a-programming-topic-to-write-about/)
-
 );
 
 print "$filename created\n.";

--- a/bin/new-article
+++ b/bin/new-article
@@ -1,57 +1,62 @@
 #!/usr/bin/env perl
-use v5.10;
+use v5.12;
 use autodie;
 use open qw(:std :utf8);
 
-use Cwd;
-use Encode;
-use ExtUtils::MakeMaker qw(prompt);
-use File::Basename qw(basename);
-use File::Spec::Functions qw(catfile);
-use Getopt::Long 'GetOptions';
-use I18N::Langinfo qw(langinfo CODESET);
-use IO::Interactive qw(is_interactive);
-use Time::Piece;
+use Cwd                   qw( cwd );
+use Encode                qw( decode );
+use ExtUtils::MakeMaker   qw( prompt );
+use File::Basename        qw( basename );
+use File::Spec::Functions qw( catfile );
+use Getopt::Long          qw( GetOptions );
+use I18N::Langinfo        qw( CODESET langinfo );
+use IO::Interactive       qw(is_interactive);
+use Time::Piece           qw( localtime );
 
 # check we're in perldotcom
 my $cwd = cwd();
-chomp $cwd; # for Mac OS?
+chomp $cwd;    # for Mac OS?
 die "$0 must be run from the root project directory!\n"
-  unless basename($cwd) eq 'perldotcom';
+    unless basename($cwd) eq 'perldotcom';
 
 my @categories = get_categories();
 
 GetOptions(
-  'title=s'       => \my $title,
-  'category=s'    => \my $category,
-  'description=s' => \(my $description),
-  'author=s'      => \(my $author = $ENV{PERLDOTCOM_AUTHOR}),
-  'help'          => \&usage,
-  'open'          => \my $open_in_editor,
-  'editor'        => \(my $editor = $ENV{EDITOR}),
+    'title=s'       => \my $title,
+    'category=s'    => \my $category,
+    'description=s' => \( my $description ),
+    'author=s'      => \( my $author = $ENV{PERLDOTCOM_AUTHOR} ),
+    'help'          => \&usage,
+    'open'          => \my $open_in_editor,
+    'editor'        => \( my $editor = $ENV{EDITOR} ),
 ) or usage();
 
-if( is_interactive ) {
-  $title  //= prompt( "What's the title of your article?" );
-  die "Article needs a title!\n" unless $title;
+if (is_interactive) {
+    $title //= prompt("What's the title of your article?");
+    die "Article needs a title!\n" unless $title;
 
-  $author //= prompt( "What's your author name?" );
-  die "Article needs an author! (See $0 --help)\n" unless $title;
+    $author //= prompt("What's your author name?");
+    die "Article needs an author! (See $0 --help)\n" unless $title;
 
-  unless( $category ) {
-    say "==== Choose a category from\n@categories\n-----";
-    $category //= prompt( "Choose a category:" );
-    die "Invalid category [$category]! (See $0 --help)"
-      unless grep $_ eq $category, @categories;
-  }
+    unless ($category) {
+        say "==== Choose a category from\n@categories\n-----";
+        $category //= prompt("Choose a category:");
+        die "Invalid category [$category]! (See $0 --help)"
+            unless grep $_ eq $category, @categories;
+    }
 }
 
-usage() unless $title && $author && $category && (grep $_ eq $category, @categories);
+usage()
+    unless $title
+    && $author
+    && $category
+    && ( grep $_ eq $category, @categories );
 
 # don't assume that the command line is a particular encoding. See what
 # CODESET is and decode it into a Perl string.
-( $title, $description, $author, $category ) = map { decode( langinfo(CODESET), $_ ) }
-	( $title, $description, $author, $category );
+( $title, $description, $author, $category )
+    = map { decode( langinfo(CODESET), $_ ) }
+    ( $title, $description, $author, $category );
 
 # prepare the file
 my $filename = lc $title;
@@ -60,7 +65,7 @@ $filename = catfile( qw/content article/, "$filename.md" );
 die "$filename.md already exists!\n" if -e $filename;
 open my $fh, '>:utf8', $filename;
 
-my $dt = localtime;
+my $dt   = localtime;
 my $date = $dt->datetime;
 
 print $fh qq(
@@ -91,9 +96,9 @@ print "$filename created\n.";
 system $editor, $filename if $open_in_editor;
 
 sub usage {
-  my $categories = join ', ', @categories;
-  print "\n$0 [OPTIONS]\n\n";
-  print "Options
+    my $categories = join ', ', @categories;
+    print "\n$0 [OPTIONS]\n\n";
+    print "Options
   --title, -t        Article title (required)
   --category, -c     One of: $categories
   --description, -d  Description (subtitle)
@@ -102,9 +107,11 @@ sub usage {
   --open, -o         Open in editor (defaults to \$EDITOR environment variable)
   --editor, -e       Editor to use (defaults to \$EDITOR environment variable)
   \n";
-  exit 0;
+    exit 0;
 }
 
 sub get_categories {
-  return map { chomp; length $_ ? $_ : () } `$^X bin/q --sql 'select distinct categories from article order by 1'`;
+    return
+        map { chomp; length $_ ? $_ : () }
+        `$^X bin/q --sql 'select distinct categories from article order by 1'`;
 }

--- a/cpanfile
+++ b/cpanfile
@@ -17,3 +17,4 @@ requires 'Path::Tiny';
 requires 'Term::ANSIColor';
 requires 'Text::CSV';
 requires 'Time::Moment';
+requires 'TOML::Tiny';

--- a/precious.toml
+++ b/precious.toml
@@ -6,7 +6,10 @@ excludes = [
 
 [commands.perlimports]
 type = "both"
-include = ["**/*.{pl,pm,t,psgi}"]
+include = [
+    "bin/new-article",
+    "**/*.{pl,pm,t,psgi}",
+]
 cmd = ["perlimports"]
 lint-flags = ["--lint"]
 tidy-flags = ["-i"]
@@ -15,14 +18,20 @@ expect-stderr = true
 
 [commands.perlcritic]
 type = "lint"
-include = ["**/*.{pl,pm,t,psgi}"]
+include = [
+    "bin/new-article",
+    "**/*.{pl,pm,t,psgi}",
+]
 cmd = ["perlcritic", "--profile=$PRECIOUS_ROOT/perlcriticrc"]
 ok-exit-codes = 0
 lint-failure-exit-codes = 2
 
 [commands.perltidy]
 type = "both"
-include = ["**/*.{pl,pm,t,psgi}"]
+include = [
+    "bin/new-article",
+    "**/*.{pl,pm,t,psgi}",
+]
 cmd = ["perltidy", "--profile=$PRECIOUS_ROOT/perltidyrc"]
 lint-flags = ["--assert-tidy", "--no-standard-output", "--outfile=/dev/null"]
 tidy-flags = ["--backup-and-modify-in-place", "--backup-file-extension=/"]
@@ -32,18 +41,24 @@ ignore-stderr = "Begin Error Output Stream"
 
 [commands.podchecker]
 type = "lint"
-include = ["**/*.{pl,pm,pod}"]
+include = [
+    "bin/new-article",
+    "**/*.{pl,pm,t,psgi}",
+]
 cmd = ["podchecker", "--warnings", "--warnings"]
 ok-exit-codes = [0, 2]
 lint-failure-exit-codes = 1
 ignore-stderr = [".+ pod syntax OK", ".+ does not contain any pod commands"]
 
-[commands.podtidy]
-type = "tidy"
-include = ["**/*.{pl,pm,pod}"]
-cmd = ["podtidy", "--columns", "100", "--inplace", "--nobackup"]
-ok-exit-codes = 0
-lint-failure-exit-codes = 1
+# [commands.podtidy]
+# type = "tidy"
+# include = [
+#     "bin/new-article",
+#     "**/*.{pl,pm,t,psgi}",
+# ]
+# cmd = ["podtidy", "--columns", "100", "--inplace", "--nobackup"]
+# ok-exit-codes = 0
+# lint-failure-exit-codes = 1
 
 [commands.shellcheck]
 type = "lint"


### PR DESCRIPTION
- **Tidy bin/new-article**
- **Switch to TOML frontmatter in new articles**
- **Add bin/new-article to precious file includes for Perl**

`prettier` doesn't seem to cope well with JSON frontmatter and I think the TOML is easier to read anyway. This script probably only gets run a few times per month, so no big deal either way.