### PR TITLE
Add Contributors and JSON links to footer; de-duplicate contributors page

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,60 @@
+# .mailmap — canonical identities for `git shortlog` / `git log` / `git blame`.
+#
+# bin/list_contributors builds the /contributors page from `git shortlog -s`,
+# which honors this file, so coalescing duplicate name/email pairs here removes
+# the duplicate (and unlinked) entries from that page. Canonical names are kept
+# in sync with data/author/*.json so each contributor stays linked to their
+# author profile.
+#
+# Format:
+#   Canonical Name <canonical-email> <alias-email>
+#   Canonical Name <canonical-email> Alias Name <alias-email>
+
+# Olaf Alders — drop the emoji-suffixed name variant
+Olaf Alders <olaf@wundersolutions.com> Olaf Alders 🇨🇦💪 <olaf@wundersolutions.com>
+
+# David Farrell
+David Farrell <davidnmfarrell@gmail.com> <1469333+dnmfarrell@users.noreply.github.com>
+
+# brian d foy
+brian d foy <briandfoy@pobox.com> <brian.d.foy@gmail.com>
+
+# Thibault Duponchelle
+Thibault Duponchelle <thibault.duponchelle@gmail.com> Thibault DUPONCHELLE <thibault.duponchelle@gmail.com>
+Thibault Duponchelle <thibault.duponchelle@gmail.com> Thibault DUPONCHELLE <thibault.duponchelle@amadeus.com>
+Thibault Duponchelle <thibault.duponchelle@gmail.com> thibaultduponchelle <thibault.duponchelle@gmail.com>
+Thibault Duponchelle <thibault.duponchelle@gmail.com> thibaultduponchelle <580360+thibaultduponchelle@users.noreply.github.com>
+
+# Kivanc Yazan
+Kivanc Yazan <kyzn@cpan.org> Kıvanç Yazan <1781335+kyzn@users.noreply.github.com>
+Kivanc Yazan <kyzn@cpan.org> <kivancyazan@gmail.com>
+
+# Rawley Fowler
+Rawley Fowler <rawleyfowler@proton.me> ivan <rawleyfowler@proton.me>
+
+# Yehor Levchenko
+Yehor Levchenko <mailyozzik@gmail.com> yozzik <mailyozzik@gmail.com>
+
+# Mathew Korica
+Mathew Korica <m.korica@alumni.utoronto.ca> Mat <m.korica@alumni.utoronto.ca>
+Mathew Korica <m.korica@alumni.utoronto.ca> matstar2 <m.korica@alumni.utoronto.ca>
+Mathew Korica <m.korica@alumni.utoronto.ca> matstar2 <31431982+matstar2@users.noreply.github.com>
+
+# Alexandru Strajeriu
+Alexandru Strajeriu <alexandru.strajeriu@evozon.com> astrajeriu <45558163+astrajeriu@users.noreply.github.com>
+
+# Mohammad Sajid Anwar
+Mohammad Sajid Anwar <mohammad.anwar@yahoo.com> Mohammad S Anwar <mohammad.anwar@yahoo.com>
+Mohammad Sajid Anwar <mohammad.anwar@yahoo.com> Mohammad S Anwar <Mohammad.Anwar@yahoo.com>
+
+# Mark Gardner
+Mark Gardner <mark.gardner@endurance.com> <mjg+github@phoenixtrap.com>
+
+# Gene Boggs
+Gene Boggs <gene@ology.net> <gene.boggs@gmail.com>
+
+# Dave Cross
+Dave Cross <dave@dave.org.uk> <dave@davecross.co.uk>
+
+# Philippe Bruhat (BooK)
+Philippe Bruhat (BooK) <book@cpan.org> <philippe@bruhat.net>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,6 +15,10 @@
         <hr>
         <li><a href="/tags">Tags</a></li>
         <hr>
+        <li><a href="/contributors">Contributors</a></li>
+        <hr>
+        <li><a href="/json">JSON</a></li>
+        <hr>
         </ul>
       </div>
       <div class="col-md-3">


### PR DESCRIPTION
Closes #291

## Changes
- **Footer Site Map**: added `Contributors` (→ `/contributors`) and `JSON` (→ `/json`) links to the Site Map list in `layouts/partials/footer.html`, matching the existing `<li><a>` + `<hr>` pattern. Both target routes already exist and build without 404.
- **Contributors de-duplication**: added a `.mailmap`. `bin/list_contributors` builds the `/contributors` page from `git shortlog -s`, which honors `.mailmap`, so several contributors that appeared multiple times under different name/email pairs now collapse to a single entry. Canonical names are aligned with `data/author/*.json` so each stays linked to their profile. Notably the emoji-suffixed `Olaf Alders` variant (previously unlinked) is gone, and `Mathew Korica` / `Mohammad Sajid Anwar` now link to their profiles.

## Testing
- `prove -l t/` passes (3/3).
- `hugo` build succeeds (exit 0); both new footer links render site-wide (homepage and article pages) and `/json/` and `/contributors/` pages are generated (no 404).
- Regenerated the contributors page with the `.mailmap` in place and confirmed each affected contributor appears exactly once and remains linked.

## Follow-up
- Filed #506 for the pre-existing invalid `<hr>` as a direct child of `<ul>` in the footer (left as-is here to match the surrounding markup).