### PR TITLE
Paginate only real articles (article + legacy), not meta pages

### DIFF
--- a/bin/list_contributors
+++ b/bin/list_contributors
@@ -50,8 +50,7 @@ say <<"HERE";
 {
   "title": "Perl.com contributors",
   "type": "about",
-  "categories": "meta",
-  "exclude_paginate": 1
+  "categories": "meta"
 }
 
 $contributors

--- a/content/about.md
+++ b/content/about.md
@@ -1,8 +1,7 @@
 {
   "title": "About Perl.com",
   "type": "about",
-  "categories": "meta",
-  "exclude_paginate": 1
+  "categories": "meta"
 }
 
 Since 1997 Perl.com has been the home for quality articles about Perl programming, news and culture. The website is managed by the [The Perl Foundation](https://www.perlfoundation.org).

--- a/content/json/index.md
+++ b/content/json/index.md
@@ -1,8 +1,7 @@
 {
   "title": "Perl.com JSON files",
   "type": "about",
-  "categories": "meta",
-  "exclude_paginate": 1
+  "categories": "meta"
 }
 
 Perl.com provides various JSON files for its articles for your programming pleasure. Get all the articles, or just the last 10 (for a smaller file):

--- a/content/latest_articles.md
+++ b/content/latest_articles.md
@@ -1,8 +1,7 @@
 {
   "title": "Latest Articles",
   "type": "latest_articles",
-  "page": "latest_articles/single.html",
-  "exclude_paginate": 1
+  "page": "latest_articles/single.html"
 }
 
 The content here doesn't matter.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,9 +3,10 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-9">
-        {{ $pages := where site.RegularPages "Type" "article" }}
+        {{ $types := slice "article" "legacy" }}
+        {{ $pages := where site.RegularPages "Type" "in" $types }}
         {{ if not .IsHome }}
-          {{ $pages = where .Pages "Type" "article" }}
+          {{ $pages = where .Pages "Type" "in" $types }}
         {{ end }}
         {{ $paginator := .Paginate $pages }}
         {{ range $paginator.Pages }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,12 +3,15 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-9">
-        {{ range $index, $page := .Paginator.Pages }}
-          {{ if not (isset $page.Params "exclude_paginate") }}
-            {{ .Render "li" }}
-          {{ end }}
+        {{ $pages := where site.RegularPages "Type" "article" }}
+        {{ if not .IsHome }}
+          {{ $pages = where .Pages "Type" "article" }}
         {{ end }}
-        {{ partial "pagination.html" .Paginator }}
+        {{ $paginator := .Paginate $pages }}
+        {{ range $paginator.Pages }}
+          {{ .Render "li" }}
+        {{ end }}
+        {{ partial "pagination.html" $paginator }}
       </div>
       <div class="col-sm-3">
         {{ partial "sidebar.html" . }}

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,3 +1,4 @@
+{{ if gt .TotalPages 0 }}
 <nav id="nav-below" class="navigation" role="navigation">
 {{if .HasNext}}<div class="older">
     <a href="{{ .Next.URL }}">&laquo; Older Posts</a>
@@ -8,3 +9,4 @@
   <div class="clearfix"></div>
   <div class="pagination">Page {{ .PageNumber }} of {{.TotalPages}}</div>
 </nav>
+{{ end }}

--- a/t/paginator.t
+++ b/t/paginator.t
@@ -4,27 +4,27 @@ use warnings;
 use File::Temp;
 use Test::More;
 
-# Integration test for the list-page paginator (issue #265).
+# Integration test for the list-page paginator (issue #265, Option B).
 #
-# The list.html template must build its paginator from article-type pages
-# only. This means:
-#   * the home paginator must NOT leak legacy pages (slugs under /pub/ or
-#     /doc/) or the root promoting-perl-community-articles page;
-#   * taxonomy term pages must still list that term's articles (scoping
-#     preserved), and must NOT leak the root promoting page.
+# The list.html template builds its paginator from BOTH article-type and
+# legacy-type pages. Legacy content (1996-2014 O'Reilly-era reprints published
+# at /pub/ and /doc/ slugs) is real content and must remain listed in the home
+# feed and on taxonomy/section pages. This guards against the earlier
+# article-only fix that orphaned ~700 legacy reprints from internal navigation.
 #
-# Note: a genuine ARTICLE also uses this slug, published at
-# /article/promoting-perl-community-articles/. That one is Type "article" and
-# SHOULD be paginated. The leak we assert against is the root section page,
-# published at /promoting-perl-community-articles/ (no /article/ prefix), which
-# is not an article and must be excluded.
+# True meta/special pages must still be excluded from the paginator. The one we
+# assert against is the root section page published at
+# /promoting-perl-community-articles/ (Type "page", no /article/ prefix). A
+# genuine ARTICLE also uses this slug, published at
+# /article/promoting-perl-community-articles/ (Type "article"); that one SHOULD
+# be paginated and is distinct from the leak.
 #
 # We build the site once with the local hugo binary and inspect the rendered
 # HTML.
 
-# The RelPermalink of the root section page that used to leak into the
+# The RelPermalink of the root section page that must NOT leak into the
 # paginator (distinct from the legitimate /article/... version).
-my $LEAK_URL = '/promoting-perl-community-articles/';
+my $LEAK = '/promoting-perl-community-articles/';
 
 my $hugo = qx{command -v hugo 2>/dev/null};
 chomp $hugo;
@@ -61,21 +61,59 @@ sub bookmark_links {
 	return @links;
 }
 
+# True if any link points at a legacy reprint slug.
+sub has_legacy {
+	return scalar( grep { m{^/pub/} || m{^/doc/} } @_ );
+}
+
 subtest home => sub {
 	my @links = bookmark_links( '' );
 	ok( scalar(@links), "home paginator has bookmark links" );
 
 	ok(
-		!( grep { $_ eq $LEAK_URL } @links ),
+		!( grep { $_ eq $LEAK } @links ),
 		"home paginator excludes the root promoting-perl-community-articles page"
 	);
+
+	# Page 1 (index.html) alone must carry at least one modern article link.
+	my @page1;
+	if ( open my $fh, '<:encoding(UTF-8)', "$dest/index.html" ) {
+		my $html = do { local $/; <$fh> };
+		close $fh;
+		while ( $html =~ /<a\b([^>]*\brel="bookmark"[^>]*)>/g ) {
+			my $attrs = $1;
+			push @page1, $1 if $attrs =~ /\bhref="([^"]*)"/;
+		}
+	}
 	ok(
-		!( grep { m{^/pub/} || m{^/doc/} } @links ),
-		"home paginator excludes legacy pages (no /pub/ or /doc/ slugs)"
-	);
-	ok(
-		scalar( grep { m{^/article/} } @links ),
+		scalar( grep { m{^/article/} } @page1 ),
 		"home paginator (page 1) includes at least one /article/ page"
+	);
+
+	# Option B: legacy reprints must appear in the home feed.
+	ok(
+		has_legacy(@links),
+		"home paginator includes legacy pages (>=1 /pub/ or /doc/ slug)"
+	);
+};
+
+subtest legacy_taxonomy_not_orphaned => sub {
+	my @links = bookmark_links( 'categories/graphics' );
+
+	ok( scalar(@links), "categories/graphics term page is non-empty" );
+	ok(
+		has_legacy(@links),
+		"categories/graphics lists legacy pages (>=1 /pub/ or /doc/ slug)"
+	);
+};
+
+subtest legacy_section => sub {
+	my @links = bookmark_links( 'legacy' );
+
+	ok( scalar(@links), "/legacy/ section page is non-empty" );
+	ok(
+		has_legacy(@links),
+		"/legacy/ section includes legacy pages (>=1 /pub/ or /doc/ slug)"
 	);
 };
 
@@ -83,7 +121,7 @@ subtest community_term => sub {
 	my @links = bookmark_links( 'categories/community' );
 
 	ok(
-		!( grep { $_ eq $LEAK_URL } @links ),
+		!( grep { $_ eq $LEAK } @links ),
 		"community term page excludes the root promoting page"
 	);
 	ok(

--- a/t/paginator.t
+++ b/t/paginator.t
@@ -1,0 +1,95 @@
+use strict;
+use warnings;
+
+use File::Temp;
+use Test::More;
+
+# Integration test for the list-page paginator (issue #265).
+#
+# The list.html template must build its paginator from article-type pages
+# only. This means:
+#   * the home paginator must NOT leak legacy pages (slugs under /pub/ or
+#     /doc/) or the root promoting-perl-community-articles page;
+#   * taxonomy term pages must still list that term's articles (scoping
+#     preserved), and must NOT leak the root promoting page.
+#
+# Note: a genuine ARTICLE also uses this slug, published at
+# /article/promoting-perl-community-articles/. That one is Type "article" and
+# SHOULD be paginated. The leak we assert against is the root section page,
+# published at /promoting-perl-community-articles/ (no /article/ prefix), which
+# is not an article and must be excluded.
+#
+# We build the site once with the local hugo binary and inspect the rendered
+# HTML.
+
+# The RelPermalink of the root section page that used to leak into the
+# paginator (distinct from the legitimate /article/... version).
+my $LEAK_URL = '/promoting-perl-community-articles/';
+
+my $hugo = qx{command -v hugo 2>/dev/null};
+chomp $hugo;
+plan skip_all => "hugo binary not found on PATH" unless $hugo;
+
+my $destdir = File::Temp->newdir(
+	DIR     => ( $ENV{TMPDIR} // '/tmp' ),
+	CLEANUP => 1,
+);
+my $dest = $destdir->dirname;
+
+my $rc = system( 'hugo', '--destination', $dest, '--quiet' );
+is( $rc, 0, "hugo build succeeded (exit 0)" );
+
+# Collect the rel="bookmark" links from a set of paginated pages: the given
+# index.html plus any page/*/index.html siblings beneath the same directory.
+sub bookmark_links {
+	my ( $base_dir ) = @_;
+	my @files = grep { -e } (
+		"$dest/$base_dir/index.html",
+		glob("$dest/$base_dir/page/*/index.html"),
+	);
+	my @links;
+	for my $file ( @files ) {
+		open my $fh, '<:encoding(UTF-8)', $file or next;
+		my $html = do { local $/; <$fh> };
+		close $fh;
+		# Grab href values from anchors carrying rel="bookmark".
+		while ( $html =~ /<a\b([^>]*\brel="bookmark"[^>]*)>/g ) {
+			my $attrs = $1;
+			push @links, $1 if $attrs =~ /\bhref="([^"]*)"/;
+		}
+	}
+	return @links;
+}
+
+subtest home => sub {
+	my @links = bookmark_links( '' );
+	ok( scalar(@links), "home paginator has bookmark links" );
+
+	ok(
+		!( grep { $_ eq $LEAK_URL } @links ),
+		"home paginator excludes the root promoting-perl-community-articles page"
+	);
+	ok(
+		!( grep { m{^/pub/} || m{^/doc/} } @links ),
+		"home paginator excludes legacy pages (no /pub/ or /doc/ slugs)"
+	);
+	ok(
+		scalar( grep { m{^/article/} } @links ),
+		"home paginator (page 1) includes at least one /article/ page"
+	);
+};
+
+subtest community_term => sub {
+	my @links = bookmark_links( 'categories/community' );
+
+	ok(
+		!( grep { $_ eq $LEAK_URL } @links ),
+		"community term page excludes the root promoting page"
+	);
+	ok(
+		scalar( grep { m{^/article/} } @links ),
+		"community term page still lists community articles (scoping preserved)"
+	);
+};
+
+done_testing();


### PR DESCRIPTION
Closes #265

## Problem

`layouts/_default/list.html` built its paginator by iterating the whole default
collection and hiding a few special pages via an `exclude_paginate` front-matter
flag. That denylist was fragile: it still leaked the root
`promoting-perl-community-articles.md` page (which never carried the flag) into
the home feed and into `/categories/community/`.

## Approach

Invert the logic: build the paginator from the pages we *want* to include, using
an allowlist of content types rather than a denylist of flags. Content pages are
`Type` `article` (the modern site) or `Type` `legacy` (the 1996–2014 O'Reilly-era
reprints, kept at their original `/pub/` and `/doc/` URLs). Meta pages (`about`,
`latest_articles`, the JSON index, the contributors page, and the root promoting
page) are excluded structurally because they are none of those types.

The filter is kind-aware so taxonomy term pages keep their per-term scoping:

```go-html-template
{{ $types := slice "article" "legacy" }}
{{ $pages := where site.RegularPages "Type" "in" $types }}
{{ if not .IsHome }}
  {{ $pages = where .Pages "Type" "in" $types }}
{{ end }}
{{ $paginator := .Paginate $pages }}
```

Both `article` and `legacy` are included everywhere, so legacy reprints remain in
the home feed *and* remain reachable through their author / tag / category pages —
nothing is orphaned. (An earlier pass that filtered to `article` only was caught in
review: it emptied ~898 taxonomy/section pages and stranded ~712 legacy articles
from internal navigation. This PR is the corrected version.)

## Changes

- **`layouts/_default/list.html`** — paginate `Type in (article, legacy)` instead
  of the whole collection filtered by `exclude_paginate`. Home uses
  `site.RegularPages`; section and term pages use their scoped `.Pages`.
- **`layouts/partials/pagination.html`** — wrap the nav in `{{ if gt .TotalPages 0 }}`
  so a genuinely-empty listing no longer emits a misleading "Page 1 of 0" control
  or an empty navigation landmark.
- **`content/about.md`, `content/json/index.md`, `content/latest_articles.md`,
  `bin/list_contributors`** — remove the now-dead `exclude_paginate` key (these are
  `Type` `about` / `latest_articles`, excluded by the type filter regardless).
- **`t/paginator.t`** — new integration test: builds the site with `hugo` and
  asserts the home feed excludes the root promoting page while including both
  articles and legacy content, that `/categories/graphics/` and `/legacy/` still
  list their legacy pages (guarding against re-orphaning), and that
  `/categories/community/` keeps its scoping.

## Testing

- `prove -l t/` → 8 tests pass (`t/metadata.t` + `t/paginator.t`).
- Red/green verified: reverting `list.html` to the article-only variant makes
  `t/paginator.t` fail 3/5 (legacy orphaned); the fix makes it pass 5/5.
- Full `hugo` build exits 0 with no errors; `/legacy/` renders 712 links across 36
  pager pages; the root `/promoting-perl-community-articles/` no longer appears in
  the home feed, while the genuine `/article/promoting-perl-community-articles/`
  still does.

## Note (out of scope)

`bin/deploy` runs `hugo build` without `--cleanDestinationDir`. It is not changed
here — this PR keeps the page count essentially unchanged vs. the live site, so the
stale-page risk is negligible — but adding that flag would be a reasonable
follow-up hardening for future listing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
