### PR TITLE
Fix paginated list pages self-canonicalizing to page 1

### DIFF
--- a/.nono/profile.json
+++ b/.nono/profile.json
@@ -1,0 +1,1 @@
+{"extends": ["oalders", "oalders-perl", "oalders-perl-net", "oalders-node", "oalders-snap", "oalders-hugo"]}

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'File::Find::Rule';
 requires 'File::Path';
 requires 'File::Spec::Functions';
 requires 'FindBin';
+requires 'HTML::Parser';
 requires 'I18N::Langinfo';
 requires 'IO::Interactive';
 requires 'IPC::Run';

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,12 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-9">
-        {{ $types := slice "article" "legacy" }}
-        {{ $pages := where site.RegularPages "Type" "in" $types }}
-        {{ if not .IsHome }}
-          {{ $pages = where .Pages "Type" "in" $types }}
-        {{ end }}
-        {{ $paginator := .Paginate $pages }}
+        {{ $paginator := .Paginate (partial "list-pages.html" .) }}
         {{ range $paginator.Pages }}
           {{ .Render "li" }}
         {{ end }}

--- a/layouts/partials/canonical-url.html
+++ b/layouts/partials/canonical-url.html
@@ -1,17 +1,22 @@
 {{- /*
-  Returns this page's own URL, pagination-aware (issue #519).
+  Returns this page's own canonical URL. Single source of truth for both the
+  rel=canonical tag (header.html) and og:url (header/ograph-twittercard.html),
+  so the two can never disagree. Precedence:
 
-  For the paginated list kinds (home/section/term) it returns the current
-  /page/N/ URL so page N identifies as itself; every other page kind returns
-  its plain .Permalink. Shared by the rel=canonical tag (header.html) and
-  og:url (header/ograph-twittercard.html) so the two can never disagree and
-  re-introduce the self-canonicalize-to-page-1 bug in a different tag.
+    1. an explicit canonicalUrl front-matter value (republished/syndicated
+       content points at the external original);
+    2. the pagination-aware self URL for the paginated list kinds
+       (home/section/term), so each /page/N/ identifies as itself rather than
+       self-canonicalizing to page 1 (issue #519);
+    3. otherwise the plain .Permalink.
 
   Paginates the same collection as list.html via list-pages.html, so Hugo
   reuses its single per-page paginator rather than erroring.
 */ -}}
 {{- $url := .Permalink -}}
-{{- if in (slice "home" "section" "term") .Kind -}}
+{{- if .Params.canonicalUrl -}}
+  {{- $url = .Params.canonicalUrl -}}
+{{- else if in (slice "home" "section" "term") .Kind -}}
   {{- $url = (.Paginate (partial "list-pages.html" .)).URL | absURL -}}
 {{- end -}}
 {{- return $url -}}

--- a/layouts/partials/canonical-url.html
+++ b/layouts/partials/canonical-url.html
@@ -1,0 +1,17 @@
+{{- /*
+  Returns this page's own URL, pagination-aware (issue #519).
+
+  For the paginated list kinds (home/section/term) it returns the current
+  /page/N/ URL so page N identifies as itself; every other page kind returns
+  its plain .Permalink. Shared by the rel=canonical tag (header.html) and
+  og:url (header/ograph-twittercard.html) so the two can never disagree and
+  re-introduce the self-canonicalize-to-page-1 bug in a different tag.
+
+  Paginates the same collection as list.html via list-pages.html, so Hugo
+  reuses its single per-page paginator rather than erroring.
+*/ -}}
+{{- $url := .Permalink -}}
+{{- if in (slice "home" "section" "term") .Kind -}}
+  {{- $url = (.Paginate (partial "list-pages.html" .)).URL | absURL -}}
+{{- end -}}
+{{- return $url -}}

--- a/layouts/partials/canonical-url.html
+++ b/layouts/partials/canonical-url.html
@@ -5,21 +5,26 @@
 
     1. an explicit canonicalUrl front-matter value (republished/syndicated
        content points at the external original);
-    2. the pagination-aware self URL for the paginated list kinds
-       (home/section/term), so each /page/N/ identifies as itself rather than
-       self-canonicalizing to page 1 (issue #519);
+    2. the pagination-aware self URL for the paginated list kinds, so each
+       /page/N/ identifies as itself rather than self-canonicalizing to page 1
+       (issue #519);
     3. otherwise the plain .Permalink.
 
-  Paginates via the shared list-pages.html partial so this call uses the same
-  collection as list.html's. Hugo caches the paginator on the first .Paginate
-  call per page and reuses it regardless of later arguments, so the shared
-  collection (not any Hugo-side validation) is what keeps this consistent with
-  the rendered listing. See list-pages.html for the full rationale.
+  Which kinds paginate is decided in one place: list-pages.html returns a
+  non-empty collection only for the paginated list kinds, so a non-empty return
+  here is exactly "this page paginates." Paginating that shared collection also
+  keeps this call consistent with list.html's rendered listing -- Hugo caches
+  the paginator on the first .Paginate call per page and reuses it regardless
+  of later arguments, so the shared collection (not any Hugo-side validation)
+  is what keeps them in sync. See list-pages.html for the full rationale.
 */ -}}
 {{- $url := .Permalink -}}
 {{- if .Params.canonicalUrl -}}
   {{- $url = .Params.canonicalUrl -}}
-{{- else if in (slice "home" "section" "term") .Kind -}}
-  {{- $url = (.Paginate (partial "list-pages.html" .)).URL | absURL -}}
+{{- else -}}
+  {{- $collection := partial "list-pages.html" . -}}
+  {{- if $collection -}}
+    {{- $url = (.Paginate $collection).URL | absURL -}}
+  {{- end -}}
 {{- end -}}
 {{- return $url -}}

--- a/layouts/partials/canonical-url.html
+++ b/layouts/partials/canonical-url.html
@@ -10,8 +10,11 @@
        self-canonicalizing to page 1 (issue #519);
     3. otherwise the plain .Permalink.
 
-  Paginates the same collection as list.html via list-pages.html, so Hugo
-  reuses its single per-page paginator rather than erroring.
+  Paginates via the shared list-pages.html partial so this call uses the same
+  collection as list.html's. Hugo caches the paginator on the first .Paginate
+  call per page and reuses it regardless of later arguments, so the shared
+  collection (not any Hugo-side validation) is what keeps this consistent with
+  the rendered listing. See list-pages.html for the full rationale.
 */ -}}
 {{- $url := .Permalink -}}
 {{- if .Params.canonicalUrl -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,28 +1,37 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
   <head>
-  <title>{{ if .Title }} {{ .Title }} {{ else }} {{ .Site.Title }} {{ end }}</title>
+  {{/* Pager for the paginated list kinds (home/section/term); false elsewhere.
+       Drives the page-number title suffix and rel=prev/next below. See #519. */}}
+  {{ $pager := false }}
+  {{ if in (slice "home" "section" "term") .Kind }}
+    {{ $pager = .Paginate (partial "list-pages.html" .) }}
+  {{ end }}
+  <title>{{ if .Title }} {{ .Title }} {{ else }} {{ .Site.Title }} {{ end }}{{ if and $pager (gt $pager.PageNumber 1) }} - Page {{ $pager.PageNumber }}{{ end }}</title>
 {{ if .Params.canonicalUrl }}
   <link rel="canonical" href="{{ .Params.canonicalUrl }}">
-{{ else if in (slice "home" "section" "term") .Kind }}
-  {{/* Paginated list pages: canonicalize each /page/N/ to itself, not page 1,
-       and expose rel=prev/next so paginated content isn't suppressed. See #519.
-       Uses the same collection as list.html so Hugo reuses one paginator. */}}
-  {{ $paginator := .Paginate (partial "list-pages.html" .) }}
-  <link rel="canonical" href="{{ $paginator.URL | absURL }}">
-  {{ if $paginator.HasPrev }}
-  <link rel="prev" href="{{ $paginator.Prev.URL | absURL }}">
-  {{ end }}
-  {{ if $paginator.HasNext }}
-  <link rel="next" href="{{ $paginator.Next.URL | absURL }}">
-  {{ end }}
 {{ else }}
-  <link rel="canonical" href="{{ .Permalink }}">
+  {{/* Pagination-aware self-canonical (each /page/N/ points at itself, not
+       page 1) via the shared partial, so canonical and og:url never diverge.
+       See #519. */}}
+  <link rel="canonical" href="{{ partial "canonical-url.html" . }}">
+{{ end }}
+{{ if $pager }}
+  {{/* rel=prev/next is a supplementary hint: Google dropped it as an indexing
+       signal in 2019, but Bing and others still honor it. The primary crawl
+       path for deep pages remains the Older/Newer Posts links in
+       pagination.html plus the self-canonical above. */}}
+  {{ if $pager.HasPrev }}
+  <link rel="prev" href="{{ $pager.Prev.URL | absURL }}">
+  {{ end }}
+  {{ if $pager.HasNext }}
+  <link rel="next" href="{{ $pager.Next.URL | absURL }}">
+  {{ end }}
 {{ end }}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{{.Description}}"/>
+  <meta name="description" content="{{ or .Description .Site.Params.description }}"/>
 {{- if .Params.authors }}
 {{- range $author_name := .Params.authors }}
 {{- $author := index hugo.Data.author $author_name }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
   <head>
-  {{/* Pager for the paginated list kinds (home/section/term); false elsewhere.
-       Drives the page-number title suffix and rel=prev/next below. See #519. */}}
+  {{/* $collection is the paginated article/legacy set for the list kinds
+       (home/section/term) and empty for everything else; list-pages.html is
+       the single source of truth for which kinds paginate. A non-empty
+       collection means this page paginates, so we build its pager -- which
+       drives the page-number title suffix and rel=prev/next below. See #519. */}}
   {{ $pager := false }}
-  {{ if in (slice "home" "section" "term") .Kind }}
-    {{ $pager = .Paginate (partial "list-pages.html" .) }}
+  {{ $collection := partial "list-pages.html" . }}
+  {{ if $collection }}
+    {{ $pager = .Paginate $collection }}
   {{ end }}
   <title>{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}{{ if and $pager (gt $pager.PageNumber 1) }} - Page {{ $pager.PageNumber }}{{ end }}</title>
   {{/* Canonical and og:url both flow through canonical-url.html (which honors

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,6 +4,18 @@
   <title>{{ if .Title }} {{ .Title }} {{ else }} {{ .Site.Title }} {{ end }}</title>
 {{ if .Params.canonicalUrl }}
   <link rel="canonical" href="{{ .Params.canonicalUrl }}">
+{{ else if in (slice "home" "section" "term") .Kind }}
+  {{/* Paginated list pages: canonicalize each /page/N/ to itself, not page 1,
+       and expose rel=prev/next so paginated content isn't suppressed. See #519.
+       Uses the same collection as list.html so Hugo reuses one paginator. */}}
+  {{ $paginator := .Paginate (partial "list-pages.html" .) }}
+  <link rel="canonical" href="{{ $paginator.URL | absURL }}">
+  {{ if $paginator.HasPrev }}
+  <link rel="prev" href="{{ $paginator.Prev.URL | absURL }}">
+  {{ end }}
+  {{ if $paginator.HasNext }}
+  <link rel="next" href="{{ $paginator.Next.URL | absURL }}">
+  {{ end }}
 {{ else }}
   <link rel="canonical" href="{{ .Permalink }}">
 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,15 +7,11 @@
   {{ if in (slice "home" "section" "term") .Kind }}
     {{ $pager = .Paginate (partial "list-pages.html" .) }}
   {{ end }}
-  <title>{{ if .Title }} {{ .Title }} {{ else }} {{ .Site.Title }} {{ end }}{{ if and $pager (gt $pager.PageNumber 1) }} - Page {{ $pager.PageNumber }}{{ end }}</title>
-{{ if .Params.canonicalUrl }}
-  <link rel="canonical" href="{{ .Params.canonicalUrl }}">
-{{ else }}
-  {{/* Pagination-aware self-canonical (each /page/N/ points at itself, not
-       page 1) via the shared partial, so canonical and og:url never diverge.
-       See #519. */}}
+  <title>{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}{{ if and $pager (gt $pager.PageNumber 1) }} - Page {{ $pager.PageNumber }}{{ end }}</title>
+  {{/* Canonical and og:url both flow through canonical-url.html (which honors
+       an explicit canonicalUrl, then pagination, then .Permalink) so the two
+       tags can never disagree. See #519. */}}
   <link rel="canonical" href="{{ partial "canonical-url.html" . }}">
-{{ end }}
 {{ if $pager }}
   {{/* rel=prev/next is a supplementary hint: Google dropped it as an indexing
        signal in 2019, but Bing and others still honor it. The primary crawl

--- a/layouts/partials/header/ograph-twittercard.html
+++ b/layouts/partials/header/ograph-twittercard.html
@@ -1,6 +1,6 @@
 <meta property="twitter:card" content="summary">
 <meta property="twitter:site" content="@PerlFoundation">
-<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:url" content="{{ partial "canonical-url.html" . }}" />
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ or .Description .Site.Params.description }}">
 <meta property="og:site_name" content="Perl.com" />

--- a/layouts/partials/list-pages.html
+++ b/layouts/partials/list-pages.html
@@ -1,19 +1,34 @@
 {{- /*
-  Returns the article + legacy page collection that list.html paginates.
-  Shared by list.html (rendering), header.html and canonical-url.html
-  (pagination-aware canonical / og:url / rel=prev/next) so every caller
-  paginates over an identical collection.
+  Returns the article + legacy page collection that list.html paginates, but
+  ONLY for the paginated list kinds (home/section/term); for every other kind
+  it returns an empty slice. This makes list-pages.html the single source of
+  truth for BOTH which kinds paginate and the collection they paginate over.
 
-  This matters because Hugo caches the paginator on the FIRST .Paginate call
-  per page and reuses it for every later call, ignoring the arguments passed
-  to those later calls (it does not validate that they match). Routing all
-  callers through this one partial is therefore what keeps the shared paginator
-  correct for all of them -- Hugo does not enforce it, so the identical
-  collection is a convention we maintain here on purpose.
+  Callers treat a non-empty return as "this page paginates" (header.html builds
+  its pager, canonical-url.html emits a pagination-aware self URL), so the kind
+  list lives in exactly one place -- add or remove a paginated kind here and
+  every caller follows. This is what prevents the two from drifting apart and
+  reintroducing issue #519 (a page whose canonical disagrees with its pager).
+
+  A paginated kind that happens to have zero article/legacy pages returns empty
+  too, which is harmless: with no page 2+, its page-1 paginator URL equals its
+  .Permalink, so the canonical/pager logic degrades to the same result either
+  way.
+
+  Sharing one collection also matters because Hugo caches the paginator on the
+  FIRST .Paginate call per page and reuses it for every later call, ignoring
+  the arguments passed to those later calls (it does not validate that they
+  match). Routing all callers through this one partial is what keeps the shared
+  paginator correct for all of them -- Hugo does not enforce it, so the
+  identical collection is a convention we maintain here on purpose.
 */ -}}
-{{- $types := slice "article" "legacy" -}}
-{{- $pages := where site.RegularPages "Type" "in" $types -}}
-{{- if not .IsHome -}}
-  {{- $pages = where .Pages "Type" "in" $types -}}
+{{- $pages := slice -}}
+{{- if in (slice "home" "section" "term") .Kind -}}
+  {{- $types := slice "article" "legacy" -}}
+  {{- if .IsHome -}}
+    {{- $pages = where site.RegularPages "Type" "in" $types -}}
+  {{- else -}}
+    {{- $pages = where .Pages "Type" "in" $types -}}
+  {{- end -}}
 {{- end -}}
 {{- return $pages -}}

--- a/layouts/partials/list-pages.html
+++ b/layouts/partials/list-pages.html
@@ -1,8 +1,15 @@
 {{- /*
   Returns the article + legacy page collection that list.html paginates.
-  Shared by list.html (for rendering) and header.html (for pagination-aware
-  canonical / rel=prev/next), so both paginate over an identical collection
-  and Hugo reuses the single per-page paginator instead of erroring.
+  Shared by list.html (rendering), header.html and canonical-url.html
+  (pagination-aware canonical / og:url / rel=prev/next) so every caller
+  paginates over an identical collection.
+
+  This matters because Hugo caches the paginator on the FIRST .Paginate call
+  per page and reuses it for every later call, ignoring the arguments passed
+  to those later calls (it does not validate that they match). Routing all
+  callers through this one partial is therefore what keeps the shared paginator
+  correct for all of them -- Hugo does not enforce it, so the identical
+  collection is a convention we maintain here on purpose.
 */ -}}
 {{- $types := slice "article" "legacy" -}}
 {{- $pages := where site.RegularPages "Type" "in" $types -}}

--- a/layouts/partials/list-pages.html
+++ b/layouts/partials/list-pages.html
@@ -1,0 +1,12 @@
+{{- /*
+  Returns the article + legacy page collection that list.html paginates.
+  Shared by list.html (for rendering) and header.html (for pagination-aware
+  canonical / rel=prev/next), so both paginate over an identical collection
+  and Hugo reuses the single per-page paginator instead of erroring.
+*/ -}}
+{{- $types := slice "article" "legacy" -}}
+{{- $pages := where site.RegularPages "Type" "in" $types -}}
+{{- if not .IsHome -}}
+  {{- $pages = where .Pages "Type" "in" $types -}}
+{{- end -}}
+{{- return $pages -}}

--- a/t/canonical.t
+++ b/t/canonical.t
@@ -102,9 +102,17 @@ subtest single_article_unchanged => sub {
 
 subtest og_url_matches_canonical => sub {
 	# og:url must agree with rel=canonical; otherwise social scrapers get a
-	# conflicting page-1 signal (the #519 bug class in a different tag).
-	for my $page ( 'index.html', 'page/2/index.html', 'article/page/2/index.html' )
-	{
+	# conflicting page-1 signal (the #519 bug class in a different tag). Cover
+	# all three paginated kinds: home, section, and term.
+	my @pages = ( 'index.html', 'page/2/index.html', 'article/page/2/index.html' );
+
+	# Add a real term page/2 if one exists (term is the third paginated kind).
+	if ( my ($term_p2) = glob("$dest/tags/*/page/2/index.html") ) {
+		( my $rel = $term_p2 ) =~ s{^\Q$dest\E/}{};
+		push @pages, $rel;
+	}
+
+	for my $page ( @pages ) {
 		SKIP: {
 			skip "no $page in this build", 1 unless -e "$dest/$page";
 			my ($canon) = head_links($page);
@@ -112,6 +120,35 @@ subtest og_url_matches_canonical => sub {
 				=~ /<meta property="og:url" content="([^"]*)"/;
 			is( $ogurl, $canon, "$page og:url matches rel=canonical" );
 		}
+	}
+};
+
+subtest canonicalurl_article_og_matches => sub {
+	# Republished articles set canonicalUrl to an EXTERNAL original. Both
+	# rel=canonical and og:url must point at that external URL (they must not
+	# diverge, and og:url must not fall back to the perl.com copy). Discovered
+	# dynamically: any built article whose canonical is off-site.
+	my @external;
+	for my $f ( glob("$dest/article/*/index.html") ) {
+		open my $fh, '<:encoding(UTF-8)', $f or next;
+		my $html = do { local $/; <$fh> };
+		close $fh;
+		my ($canon) = $html =~ /<link rel="canonical" href="([^"]*)">/;
+		next unless defined $canon;
+		next if $canon =~ m{^\Q$BASE/\E};    # self-canonical (on-site) — skip
+		my ($ogurl) = $html =~ /<meta property="og:url" content="([^"]*)"/;
+		push @external, { canon => $canon, ogurl => $ogurl // '' };
+	}
+
+	SKIP: {
+		skip "no article with an external canonicalUrl in this build", 1
+			unless @external;
+		my @bad = grep { $_->{ogurl} ne $_->{canon} } @external;
+		diag( "mismatch: canonical=$_->{canon} og:url=$_->{ogurl}" ) for @bad;
+		is( scalar @bad, 0,
+			"all "
+				. scalar(@external)
+				. " external-canonical article(s): og:url == rel=canonical" );
 	}
 };
 
@@ -139,9 +176,11 @@ subtest paginated_title_has_page_number => sub {
 		"home (page 1) title has no page-number suffix" );
 	SKIP: {
 		skip "no page/2 in this build", 1 unless -e "$dest/page/2/index.html";
-		like( slurp('page/2/index.html'),
-			qr{<title>[^<]*- Page 2[^<]*</title>},
-			"/page/2/ title carries '- Page 2' suffix" );
+		my ($title) = slurp('page/2/index.html') =~ m{<title>([^<]*)</title>};
+		like( $title, qr{ - Page 2\z}, "/page/2/ title ends with ' - Page 2'" );
+		# Exactly one space each side of the dash — guards the prior
+		# double-space regression from the title's padding.
+		unlike( $title, qr{  }, "/page/2/ title has no double space" );
 	}
 };
 

--- a/t/canonical.t
+++ b/t/canonical.t
@@ -44,6 +44,15 @@ sub head_links {
 	return ( $canon, $prev, $next );
 }
 
+# Return the whole rendered <head>-ish blob for a page (for tag-by-tag checks).
+sub slurp {
+	my ( $rel_path ) = @_;
+	open my $fh, '<:encoding(UTF-8)', "$dest/$rel_path" or return '';
+	my $html = do { local $/; <$fh> };
+	close $fh;
+	return $html;
+}
+
 subtest home_page_1 => sub {
 	my ( $canon, $prev, $next ) = head_links( 'index.html' );
 	is( $canon, "$BASE/", "home canonicalizes to itself" );
@@ -89,6 +98,51 @@ subtest single_article_unchanged => sub {
 		"single article canonicalizes to its own permalink" );
 	is( $prev, undef, "single article has no rel=prev" );
 	is( $next, undef, "single article has no rel=next" );
+};
+
+subtest og_url_matches_canonical => sub {
+	# og:url must agree with rel=canonical; otherwise social scrapers get a
+	# conflicting page-1 signal (the #519 bug class in a different tag).
+	for my $page ( 'index.html', 'page/2/index.html', 'article/page/2/index.html' )
+	{
+		SKIP: {
+			skip "no $page in this build", 1 unless -e "$dest/$page";
+			my ($canon) = head_links($page);
+			my ($ogurl) = slurp($page)
+				=~ /<meta property="og:url" content="([^"]*)"/;
+			is( $ogurl, $canon, "$page og:url matches rel=canonical" );
+		}
+	}
+};
+
+subtest meta_description_has_fallback => sub {
+	# Now-indexable list pages must carry a non-empty description, falling back
+	# to the site description when the page supplies none.
+	my ($site_desc) =
+		slurp('index.html') =~ /<meta name="description" content="([^"]*)"/;
+	for my $page ( 'index.html', 'page/2/index.html', 'article/index.html' ) {
+		SKIP: {
+			skip "no $page in this build", 1 unless -e "$dest/$page";
+			my ($desc) =
+				slurp($page) =~ /<meta name="description" content="([^"]*)"/;
+			ok( length $desc, "$page has a non-empty meta description" );
+		}
+	}
+	ok( length $site_desc, "site description fallback is non-empty" );
+};
+
+subtest paginated_title_has_page_number => sub {
+	# Page 1 has no suffix; deeper pages disambiguate with "- Page N".
+	like( slurp('index.html'), qr{<title>[^<]*</title>},
+		"home has a title" );
+	unlike( slurp('index.html'), qr{<title>[^<]*- Page \d+[^<]*</title>},
+		"home (page 1) title has no page-number suffix" );
+	SKIP: {
+		skip "no page/2 in this build", 1 unless -e "$dest/page/2/index.html";
+		like( slurp('page/2/index.html'),
+			qr{<title>[^<]*- Page 2[^<]*</title>},
+			"/page/2/ title carries '- Page 2' suffix" );
+	}
 };
 
 done_testing();

--- a/t/canonical.t
+++ b/t/canonical.t
@@ -16,11 +16,20 @@ use Test::More;
 # and adds rel=prev/next markup. This test builds the real site with the local
 # hugo binary and asserts the rendered <head> links.
 
-my $BASE = 'https://www.perl.com';
-
 my $hugo = qx{command -v hugo 2>/dev/null};
 chomp $hugo;
 plan skip_all => "hugo binary not found on PATH" unless $hugo;
+
+# Derive the base URL from Hugo's own resolved config rather than hardcoding it,
+# so this test tracks hugo.toml if baseURL ever changes. `hugo config` prints
+# e.g. `baseurl = 'https://www.perl.com/'`; strip the trailing slash since every
+# assertion below appends its own path.
+my $BASE = do {
+	my ($url) = qx{hugo config 2>/dev/null} =~ /^baseurl\s*=\s*['"]?([^'"\s]+)/mi;
+	$url //= 'https://www.perl.com/';
+	$url =~ s{/+$}{};
+	$url;
+};
 
 my $destdir = File::Temp->newdir(
 	DIR     => ( $ENV{TMPDIR} // '/tmp' ),
@@ -98,6 +107,32 @@ subtest single_article_unchanged => sub {
 		"single article canonicalizes to its own permalink" );
 	is( $prev, undef, "single article has no rel=prev" );
 	is( $next, undef, "single article has no rel=next" );
+};
+
+subtest single_page_term_no_pagination => sub {
+	# A term page (tag/author/category) with only one page of results must
+	# canonicalize to its own unpaginated URL and carry no rel=prev/next --
+	# the opposite end of the same logic as the multi-page term checks below.
+	my $single_term;
+	for my $idx ( glob("$dest/tags/*/index.html"),
+		glob("$dest/authors/*/index.html") )
+	{
+		( my $dir = $idx ) =~ s{/index\.html$}{};
+		next if -e "$dir/page/2/index.html";    # want a SINGLE-page term
+		$single_term = $idx;
+		last;
+	}
+	ok( $single_term, "found a single-page term to check" )
+		or return;
+
+	( my $rel = $single_term ) =~ s{^\Q$dest\E/}{};
+	my ( $canon, $prev, $next ) = head_links( $rel );
+
+	( my $expected = $rel ) =~ s{index\.html$}{};
+	is( $canon, "$BASE/$expected",
+		"single-page term canonicalizes to its own URL" );
+	is( $prev, undef, "single-page term has no rel=prev" );
+	is( $next, undef, "single-page term has no rel=next" );
 };
 
 subtest og_url_matches_canonical => sub {

--- a/t/canonical.t
+++ b/t/canonical.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 
-use File::Temp;
+use HTML::Parser;
+use Path::Tiny;
 use Test::More;
 
 # Regression test for issue #519.
@@ -31,35 +32,71 @@ my $BASE = do {
 	$url;
 };
 
-my $destdir = File::Temp->newdir(
-	DIR     => ( $ENV{TMPDIR} // '/tmp' ),
-	CLEANUP => 1,
-);
-my $dest = $destdir->dirname;
+# Cleaned up when $destdir goes out of scope at end of script. Path::Tiny uses
+# File::Temp underneath, which honors $TMPDIR and falls back to the system temp
+# dir when it is unset.
+my $destdir = Path::Tiny->tempdir;
+my $dest    = "$destdir";
 
 my $rc = system( 'hugo', '--destination', $dest, '--quiet' );
 is( $rc, 0, "hugo build succeeded (exit 0)" );
 
-# Return (canonical, prev, next) hrefs from a rendered page's <head>.
-sub head_links {
-	my ( $rel_path ) = @_;
-	my $file = "$dest/$rel_path";
-	open my $fh, '<:encoding(UTF-8)', $file or return;
-	my $html = do { local $/; <$fh> };
-	close $fh;
-	my ($canon) = $html =~ /<link rel="canonical" href="([^"]*)">/;
-	my ($prev)  = $html =~ /<link rel="prev" href="([^"]*)">/;
-	my ($next)  = $html =~ /<link rel="next" href="([^"]*)">/;
-	return ( $canon, $prev, $next );
+# Extract the <head> facts we assert on with HTML::Parser -- a real HTML
+# tokenizer, so attribute order, quoting, and whitespace can't fool us the way
+# a regex would. Returns a hashref: link_canonical / link_prev / link_next
+# hrefs, og_url, description, and the decoded <title> text.
+sub parse_head {
+	my ( $html ) = @_;
+	my %f;
+	my $in_title = 0;
+	my $p = HTML::Parser->new(
+		api_version => 3,
+		start_h     => [
+			sub {
+				my ( $tag, $attr ) = @_;
+				if ( $tag eq 'link' ) {
+					my $rel = $attr->{rel} // return;
+					$f{"link_$rel"} = $attr->{href}
+						if $rel eq 'canonical'
+						|| $rel eq 'prev'
+						|| $rel eq 'next';
+				}
+				elsif ( $tag eq 'meta' ) {
+					if ( ( $attr->{property} // '' ) eq 'og:url' ) {
+						$f{og_url} = $attr->{content};
+					}
+					elsif ( ( $attr->{name} // '' ) eq 'description' ) {
+						$f{description} = $attr->{content};
+					}
+				}
+				elsif ( $tag eq 'title' ) {
+					$in_title = 1;
+				}
+			},
+			'tagname, attr'
+		],
+		text_h => [ sub { $f{title} .= $_[0] if $in_title }, 'dtext' ],
+		end_h  => [ sub { $in_title = 0 if $_[0] eq 'title' }, 'tagname' ],
+	);
+	$p->parse( $html );
+	$p->eof;
+	return \%f;
 }
 
-# Return the whole rendered <head>-ish blob for a page (for tag-by-tag checks).
-sub slurp {
+# Parsed <head> facts for a rendered page (rel path under $dest), or undef if
+# the page was not built.
+sub head_of {
 	my ( $rel_path ) = @_;
-	open my $fh, '<:encoding(UTF-8)', "$dest/$rel_path" or return '';
-	my $html = do { local $/; <$fh> };
-	close $fh;
-	return $html;
+	my $file = path( $dest, $rel_path );
+	return unless $file->exists;
+	return parse_head( $file->slurp_utf8 );
+}
+
+# Convenience: (canonical, prev, next) hrefs for a page.
+sub head_links {
+	my ( $rel_path ) = @_;
+	my $h = head_of( $rel_path ) or return;
+	return ( $h->{link_canonical}, $h->{link_prev}, $h->{link_next} );
 }
 
 subtest home_page_1 => sub {
@@ -150,10 +187,9 @@ subtest og_url_matches_canonical => sub {
 	for my $page ( @pages ) {
 		SKIP: {
 			skip "no $page in this build", 1 unless -e "$dest/$page";
-			my ($canon) = head_links($page);
-			my ($ogurl) = slurp($page)
-				=~ /<meta property="og:url" content="([^"]*)"/;
-			is( $ogurl, $canon, "$page og:url matches rel=canonical" );
+			my $h = head_of($page);
+			is( $h->{og_url}, $h->{link_canonical},
+				"$page og:url matches rel=canonical" );
 		}
 	}
 };
@@ -165,14 +201,11 @@ subtest canonicalurl_article_og_matches => sub {
 	# dynamically: any built article whose canonical is off-site.
 	my @external;
 	for my $f ( glob("$dest/article/*/index.html") ) {
-		open my $fh, '<:encoding(UTF-8)', $f or next;
-		my $html = do { local $/; <$fh> };
-		close $fh;
-		my ($canon) = $html =~ /<link rel="canonical" href="([^"]*)">/;
+		my $h = parse_head( path($f)->slurp_utf8 );
+		my $canon = $h->{link_canonical};
 		next unless defined $canon;
 		next if $canon =~ m{^\Q$BASE/\E};    # self-canonical (on-site) — skip
-		my ($ogurl) = $html =~ /<meta property="og:url" content="([^"]*)"/;
-		push @external, { canon => $canon, ogurl => $ogurl // '' };
+		push @external, { canon => $canon, ogurl => $h->{og_url} // '' };
 	}
 
 	SKIP: {
@@ -190,28 +223,28 @@ subtest canonicalurl_article_og_matches => sub {
 subtest meta_description_has_fallback => sub {
 	# Now-indexable list pages must carry a non-empty description, falling back
 	# to the site description when the page supplies none.
-	my ($site_desc) =
-		slurp('index.html') =~ /<meta name="description" content="([^"]*)"/;
+	my $site_desc = ( head_of('index.html') // {} )->{description};
 	for my $page ( 'index.html', 'page/2/index.html', 'article/index.html' ) {
 		SKIP: {
 			skip "no $page in this build", 1 unless -e "$dest/$page";
-			my ($desc) =
-				slurp($page) =~ /<meta name="description" content="([^"]*)"/;
-			ok( length $desc, "$page has a non-empty meta description" );
+			my $desc = head_of($page)->{description};
+			ok( defined $desc && length $desc,
+				"$page has a non-empty meta description" );
 		}
 	}
-	ok( length $site_desc, "site description fallback is non-empty" );
+	ok( defined $site_desc && length $site_desc,
+		"site description fallback is non-empty" );
 };
 
 subtest paginated_title_has_page_number => sub {
 	# Page 1 has no suffix; deeper pages disambiguate with "- Page N".
-	like( slurp('index.html'), qr{<title>[^<]*</title>},
-		"home has a title" );
-	unlike( slurp('index.html'), qr{<title>[^<]*- Page \d+[^<]*</title>},
+	my $home_title = ( head_of('index.html') // {} )->{title};
+	ok( defined $home_title && length $home_title, "home has a title" );
+	unlike( $home_title // '', qr{- Page \d+},
 		"home (page 1) title has no page-number suffix" );
 	SKIP: {
 		skip "no page/2 in this build", 1 unless -e "$dest/page/2/index.html";
-		my ($title) = slurp('page/2/index.html') =~ m{<title>([^<]*)</title>};
+		my $title = head_of('page/2/index.html')->{title};
 		like( $title, qr{ - Page 2\z}, "/page/2/ title ends with ' - Page 2'" );
 		# Exactly one space each side of the dash — guards the prior
 		# double-space regression from the title's padding.

--- a/t/canonical.t
+++ b/t/canonical.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+
+use File::Temp;
+use Test::More;
+
+# Regression test for issue #519.
+#
+# header.html previously emitted `<link rel="canonical" href="{{ .Permalink }}">`
+# on every page. On a paginated list page, Hugo's .Permalink is the *page-1*
+# URL, so every /page/N/ self-canonicalized to page 1 -- telling search engines
+# that pages 2..N (which hold unique article/legacy content) are duplicates of
+# page 1 and should be dropped from the index.
+#
+# The fix makes the canonical pagination-aware (each /page/N/ points at itself)
+# and adds rel=prev/next markup. This test builds the real site with the local
+# hugo binary and asserts the rendered <head> links.
+
+my $BASE = 'https://www.perl.com';
+
+my $hugo = qx{command -v hugo 2>/dev/null};
+chomp $hugo;
+plan skip_all => "hugo binary not found on PATH" unless $hugo;
+
+my $destdir = File::Temp->newdir(
+	DIR     => ( $ENV{TMPDIR} // '/tmp' ),
+	CLEANUP => 1,
+);
+my $dest = $destdir->dirname;
+
+my $rc = system( 'hugo', '--destination', $dest, '--quiet' );
+is( $rc, 0, "hugo build succeeded (exit 0)" );
+
+# Return (canonical, prev, next) hrefs from a rendered page's <head>.
+sub head_links {
+	my ( $rel_path ) = @_;
+	my $file = "$dest/$rel_path";
+	open my $fh, '<:encoding(UTF-8)', $file or return;
+	my $html = do { local $/; <$fh> };
+	close $fh;
+	my ($canon) = $html =~ /<link rel="canonical" href="([^"]*)">/;
+	my ($prev)  = $html =~ /<link rel="prev" href="([^"]*)">/;
+	my ($next)  = $html =~ /<link rel="next" href="([^"]*)">/;
+	return ( $canon, $prev, $next );
+}
+
+subtest home_page_1 => sub {
+	my ( $canon, $prev, $next ) = head_links( 'index.html' );
+	is( $canon, "$BASE/", "home canonicalizes to itself" );
+	is( $prev, undef, "home (page 1) has no rel=prev" );
+	is( $next, "$BASE/page/2/", "home advertises rel=next -> /page/2/" );
+};
+
+subtest home_page_2 => sub {
+	my ( $canon, $prev, $next ) = head_links( 'page/2/index.html' );
+
+	# The bug: this used to be "$BASE/" (self-canonicalized away to page 1).
+	is( $canon, "$BASE/page/2/", "/page/2/ canonicalizes to ITSELF, not page 1" );
+	is( $prev, "$BASE/", "/page/2/ has rel=prev -> home" );
+	is( $next, "$BASE/page/3/", "/page/2/ has rel=next -> /page/3/" );
+};
+
+subtest section_page_2 => sub {
+	my $f = 'article/page/2/index.html';
+	SKIP: {
+		skip "no /article/page/2/ in this build", 3 unless -e "$dest/$f";
+		my ( $canon, $prev, $next ) = head_links( $f );
+		is( $canon, "$BASE/article/page/2/",
+			"/article/page/2/ canonicalizes to itself" );
+		is( $prev, "$BASE/article/", "/article/page/2/ has rel=prev" );
+		is( $next, "$BASE/article/page/3/", "/article/page/2/ has rel=next" );
+	}
+};
+
+subtest single_article_unchanged => sub {
+	# A single article page must still self-canonicalize to its own permalink
+	# and carry no pagination markup.
+	my ($single) =
+		grep { $_ !~ m{/page/\d+/index\.html$} }
+		glob("$dest/article/*/index.html");
+	ok( $single, "found a single article page to check" )
+		or return;
+
+	( my $rel = $single ) =~ s{^\Q$dest\E/}{};
+	my ( $canon, $prev, $next ) = head_links( $rel );
+
+	( my $expected = $rel ) =~ s{index\.html$}{};
+	is( $canon, "$BASE/$expected",
+		"single article canonicalizes to its own permalink" );
+	is( $prev, undef, "single article has no rel=prev" );
+	is( $next, undef, "single article has no rel=next" );
+};
+
+done_testing();


### PR DESCRIPTION
Closes #519

## Problem

`header.html` emitted `<link rel="canonical" href="{{ .Permalink }}">` on every page. On paginated list pages Hugo's `.Permalink` resolves to the **page-1** URL, so every `/page/N/` self-canonicalized to page 1. That tells search engines pages 2–58 (unique article + legacy content) are duplicates of page 1 and can be dropped from the index.

## Changes

- **Pagination-aware self-canonical**: each `/page/N/` now canonicalizes to itself (home, `/article/` section, and taxonomy **term** pages). Added `rel="prev"`/`rel="next"` on paginated pages.
- **Single source of truth** (`layouts/partials/canonical-url.html`): both `rel=canonical` and `og:url` flow through one partial with precedence `canonicalUrl` → pagination-aware self URL → `.Permalink`, so the two tags can never diverge. This also fixed a pre-existing bug where `og:url` on republished articles pointed at perl.com while `rel=canonical` pointed at the external original — they now agree (external), per the Open Graph spec.
- **Shared collection partial** (`layouts/partials/list-pages.html`): `list.html` and the head both paginate the identical article+legacy collection, so Hugo's cached per-page paginator stays consistent.
- **Newly-indexable-page hygiene**: meta description now falls back to the site description (previously blank on list pages); paginated `<title>` gets a `- Page N` suffix to reduce duplicate-title signals.

## Testing

- New `t/canonical.t` integration test builds the real site and asserts rendered `<head>`: self-referential canonicals, prev/next boundaries, `og:url == rel=canonical` (incl. 12 external-canonical articles and term `page/2`), non-empty descriptions, and no double-space titles. Red-green verified (fails when the bug is reintroduced).
- Full suite: 22/22 pass.
- Built clean with both local Hugo v0.161.1 and the deploy image `hugomods/hugo:0.160.1` (210 paginator pages, correct output).
- Reviewed via `/code-review-intense-flow` (general + security + frontend + SEO), 3 rounds to clean.
