### PR TITLE
Add make start-tailscale to serve the dev site over Tailscale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,15 @@ json: ## create the JSON files (static/json)
 contributors:
 	perl bin/list_contributors > content/contributors.md
 
+HUGO_SERVER_FLAGS=--buildDrafts --buildFuture --disableFastRender -d built --config hugo.toml
+
 .PHONY: start
-start: json contributors ## start the local server
-	hugo server --buildDrafts --buildFuture --disableFastRender -d built --config hugo.toml
+start: json contributors ## start the local server (see start-tailscale to expose it)
+	hugo server $(HUGO_SERVER_FLAGS)
+
+.PHONY: start-tailscale
+start-tailscale: json contributors ## start the server bound to your Tailscale IP (reachable on your tailnet)
+	hugo server --bind $(shell tailscale ip -4 | head -1) --baseURL http://$(shell tailscale ip -4 | head -1):1313/ $(HUGO_SERVER_FLAGS)
 
 .PHONY: legacy-start
 legacy-start: json contributors ## start the local server


### PR DESCRIPTION
Adds a `make start-tailscale` target that runs `hugo server` bound to the machine's Tailscale IP, with a matching `--baseURL`, so the local dev site is reachable from other devices on the tailnet without exposing it to the wider LAN.

- Shared server flags are factored into a `HUGO_SERVER_FLAGS` variable so `start` and `start-tailscale` stay in sync.
- `start` is unchanged in behaviour (still binds to localhost).
- `start-tailscale` shells out to `tailscale ip -4` at run time, so it requires the `tailscale` CLI on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)