### PR TITLE
Relabel Reddit sidebar widget to reddit.com/r/perl

### DIFF
--- a/layouts/partials/reddit.html
+++ b/layouts/partials/reddit.html
@@ -1,5 +1,60 @@
 <div class="row" style="margin-top:20px">
-  <div class="col-sm-12 centering">
+  <div id="reddit-widget" class="col-sm-12 centering">
     <script src="https://www.reddit.com/r/perl/hot/.embed?limit=10&t=all" type="text/javascript"></script>
   </div>
 </div>
+<script type="text/javascript">
+  // Reddit's legacy blog-widget labels itself "links from perl.reddit.com"
+  // (its old per-subreddit subdomain alias). Rewrite that to the canonical
+  // reddit.com/r/perl. Scoped to the widget's own text nodes so link hrefs
+  // are left untouched.
+  //
+  // Assumes the legacy `.embed` widget writes plain markup into this document
+  // (it uses document.write, not a cross-origin iframe) with "perl.reddit.com"
+  // contiguous in a single text node. If Reddit ever changes that, this becomes
+  // a silent no-op — verify in a real browser after any Reddit-side change.
+  // The sidebar partial renders once per page, so the id is unique.
+  (function () {
+    var container = document.getElementById("reddit-widget");
+    if (!container) return;
+
+    function relabel() {
+      var changed = false;
+      var walker = document.createTreeWalker(
+        container,
+        NodeFilter.SHOW_TEXT,
+        null,
+        false
+      );
+      var node;
+      while ((node = walker.nextNode())) {
+        // A fresh global regex per node avoids the g-flag + lastIndex footgun.
+        var rewritten = node.nodeValue.replace(
+          /perl\.reddit\.com/gi,
+          "reddit.com/r/perl"
+        );
+        if (rewritten !== node.nodeValue) {
+          node.nodeValue = rewritten;
+          changed = true;
+        }
+      }
+      return changed;
+    }
+
+    // The widget renders via document.write during load, so the text usually
+    // exists already. Observe for late/async rendering just in case, but stop
+    // observing once the page has loaded so the observer can't leak for the
+    // page's lifetime when the label never appears (e.g. blocked by an ad
+    // blocker).
+    if (!relabel()) {
+      var observer = new MutationObserver(function () {
+        if (relabel()) observer.disconnect();
+      });
+      observer.observe(container, { childList: true, subtree: true });
+      window.addEventListener("load", function () {
+        relabel();
+        observer.disconnect();
+      });
+    }
+  })();
+</script>


### PR DESCRIPTION
## What

The Reddit blog widget in the sidebar labels its own header **"links from perl.reddit.com"** — Reddit's old per-subreddit subdomain alias for `reddit.com/r/perl`. It's confusing/dated. This rewrites that label to the canonical **reddit.com/r/perl**.

## How

The label is text Reddit's `.embed` script writes into the page, so it can't be changed server-side. Instead, a small scoped script runs after the widget renders:

- Adds `id="reddit-widget"` to the container.
- A `TreeWalker` replaces `perl.reddit.com` → `reddit.com/r/perl` in the widget's **text nodes only**, leaving link `href`s intact.
- A `MutationObserver` fallback covers late/async render and **disconnects on `load`** so it can't leak for the page's lifetime (e.g. if an ad blocker blocks the Reddit script and the label never appears).

## Notes / verification needed

The rewrite assumes the legacy widget writes **plain, same-document markup** (via `document.write`, not a cross-origin iframe) with `perl.reddit.com` in a **single contiguous text node**. If either is false, the script is a harmless no-op — it never touches anything else on the page.

⚠️ Please confirm in a real browser (reddit.com is unreachable from the dev sandbox): the sidebar header should read **"links from reddit.com/r/perl"**, and `#reddit-widget`'s children should be plain markup, not an `<iframe>`.

## Review

Ran the intense code-review flow (general + security + frontend + playwright). Security clean (text-node assignment, no XSS; no new supply-chain risk). Minor robustness nits (observer leak, case sensitivity, g-flag/lastIndex footgun) all addressed. The one open item is the live-browser verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)